### PR TITLE
[BE] Fix JWT userId mapping causing task features failure #28

### DIFF
--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -7,9 +7,13 @@ import { PrismaRefreshRepository } from './repositories/prisma-refresh-token.rep
 import { JwtModule } from '@nestjs/jwt';
 import { REFRESH_TOKEN_REPOSITORY } from './repositories/refresh-token';
 import { JwtStrategy } from './strategies/jwt.strategy';
+import { PassportModule } from '@nestjs/passport';
 
 @Module({
-  imports: [UsersModule, ConfigModule,
+  imports: [
+    UsersModule, 
+    ConfigModule,
+    PassportModule,
     JwtModule.register({
       secret: process.env.JWT_ACCESS_SECRET,
     }),

--- a/backend/src/modules/auth/strategies/jwt.strategy.ts
+++ b/backend/src/modules/auth/strategies/jwt.strategy.ts
@@ -15,9 +15,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     }
 
     async validate(payload: JwtPayload) {
-        return {
-            id: payload.sub,
-            email: payload.email,
-        };
+        return payload;
     }
 }


### PR DESCRIPTION
## Description

Fix an issue where userId was not correctly extracted from JWT, causing task-related features (e.g., create task) to fail with Prisma error Argument user is missing.

The root cause was a mismatch between JWT payload (sub) and the mapped field in request.user from JwtStrategy.validate(). This PR standardizes the mapping by returning userId from the strategy and updating usages to ensure consistent access across the application.


## Issue Link

[](https://github.com/lyoven2004/todo-app/issues/28)


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Test update
- [ ] Build / CI update
- [ ] Chore / Maintenance