### PR TITLE
[INFRA] Setup Github Actions CD pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: CD
 
 on:
   push:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,77 +31,77 @@ jobs:
               - '.github/workflows/deploy.yml'
 
   deploy_backend:
-  needs: detect_changed_paths
-  if: needs.detect_changed_paths.outputs.backend == 'true'
-  runs-on: ubuntu-latest
+    needs: detect_changed_paths
+    if: needs.detect_changed_paths.outputs.backend == 'true'
+    runs-on: ubuntu-latest
 
-  defaults:
-    run:
-      working-directory: ./backend
+    defaults:
+      run:
+        working-directory: ./backend
 
-  steps:
-    - name: Checkout source code
-      uses: actions/checkout@v4
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Build and push backend image
-      run: |
-        docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/todo-backend:latest .
-        docker push ${{ secrets.DOCKERHUB_USERNAME }}/todo-backend:latest
+      - name: Build and push backend image
+        run: |
+          docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/todo-backend:latest .
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/todo-backend:latest
 
-    - name: Deploy backend on server
-      uses: appleboy/ssh-action@v1.0.3
-      with:
-        host: ${{ secrets.SERVER_HOST }}
-        username: ${{ secrets.SERVER_USER }}
-        key: ${{ secrets.SERVER_SSH_KEY }}
-        script: |
-          cd /home/ubuntu/todo-deploy
-          docker compose pull backend
-          docker compose up -d backend
-          docker compose exec -T backend npx prisma migrate deploy
+      - name: Deploy backend on server
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            cd /home/ubuntu/todo-deploy
+            docker compose pull backend
+            docker compose up -d backend
+            docker compose exec -T backend npx prisma migrate deploy
 
   deploy_frontend:
-  needs: detect_changed_paths
-  if: needs.detect_changed_paths.outputs.frontend == 'true'
-  runs-on: ubuntu-latest
+    needs: detect_changed_paths
+    if: needs.detect_changed_paths.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
 
-  defaults:
-    run:
-      working-directory: ./frontend
+    defaults:
+      run:
+        working-directory: ./frontend
 
-  steps:
-    - name: Checkout source code
-      uses: actions/checkout@v4
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
 
-    - name: Setup pnpm
-      uses: pnpm/action-setup@v4
-      with:
-        version: 9
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-    - name: Build and push frontend image
-      run: |
-        docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/todo-frontend:latest .
-        docker push ${{ secrets.DOCKERHUB_USERNAME }}/todo-frontend:latest
+      - name: Build and push frontend image
+        run: |
+          docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/todo-frontend:latest .
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/todo-frontend:latest
 
-    - name: Deploy frontend on server
-      uses: appleboy/ssh-action@v1.0.3
-      with:
-        host: ${{ secrets.SERVER_HOST }}
-        username: ${{ secrets.SERVER_USER }}
-        key: ${{ secrets.SERVER_SSH_KEY }}
-        script: |
-          cd /home/ubuntu/todo-deploy
-          docker compose pull frontend
-          docker compose up -d frontend
+      - name: Deploy frontend on server
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            cd /home/ubuntu/todo-deploy
+            docker compose pull frontend
+            docker compose up -d frontend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,107 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  workflow_dispatch:
+
+jobs:
+  detect_changed_paths:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+              - '.github/workflows/deploy.yml'
+            frontend:
+              - 'frontend/**'
+              - '.github/workflows/deploy.yml'
+
+  deploy_backend:
+  needs: detect_changed_paths
+  if: needs.detect_changed_paths.outputs.backend == 'true'
+  runs-on: ubuntu-latest
+
+  defaults:
+    run:
+      working-directory: ./backend
+
+  steps:
+    - name: Checkout source code
+      uses: actions/checkout@v4
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build and push backend image
+      run: |
+        docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/todo-backend:latest .
+        docker push ${{ secrets.DOCKERHUB_USERNAME }}/todo-backend:latest
+
+    - name: Deploy backend on server
+      uses: appleboy/ssh-action@v1.0.3
+      with:
+        host: ${{ secrets.SERVER_HOST }}
+        username: ${{ secrets.SERVER_USER }}
+        key: ${{ secrets.SERVER_SSH_KEY }}
+        script: |
+          cd /home/ubuntu/todo-deploy
+          docker compose pull backend
+          docker compose up -d backend
+          docker compose exec -T backend npx prisma migrate deploy
+
+  deploy_frontend:
+  needs: detect_changed_paths
+  if: needs.detect_changed_paths.outputs.frontend == 'true'
+  runs-on: ubuntu-latest
+
+  defaults:
+    run:
+      working-directory: ./frontend
+
+  steps:
+    - name: Checkout source code
+      uses: actions/checkout@v4
+
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 9
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build and push frontend image
+      run: |
+        docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/todo-frontend:latest .
+        docker push ${{ secrets.DOCKERHUB_USERNAME }}/todo-frontend:latest
+
+    - name: Deploy frontend on server
+      uses: appleboy/ssh-action@v1.0.3
+      with:
+        host: ${{ secrets.SERVER_HOST }}
+        username: ${{ secrets.SERVER_USER }}
+        key: ${{ secrets.SERVER_SSH_KEY }}
+        script: |
+          cd /home/ubuntu/todo-deploy
+          docker compose pull frontend
+          docker compose up -d frontend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,6 @@ jobs:
             cd /home/ubuntu/todo-app
             sudo docker compose pull backend
             sudo docker compose up -d backend
-            sudo docker compose exec -T backend npx prisma migrate deploy
 
   deploy_frontend:
     needs: detect_changed_paths

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,10 +61,10 @@ jobs:
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
           script: |
-            cd /home/ubuntu/todo-deploy
-            docker compose pull backend
-            docker compose up -d backend
-            docker compose exec -T backend npx prisma migrate deploy
+            cd /home/ubuntu/todo-app
+            sudo docker compose pull backend
+            sudo docker compose up -d backend
+            sudo docker compose exec -T backend npx prisma migrate deploy
 
   deploy_frontend:
     needs: detect_changed_paths
@@ -102,6 +102,6 @@ jobs:
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
           script: |
-            cd /home/ubuntu/todo-deploy
-            docker compose pull frontend
-            docker compose up -d frontend
+            cd /home/ubuntu/todo-app
+            sudo docker compose pull frontend
+            sudo docker compose up -d frontend


### PR DESCRIPTION
## Description
 
<!-- Describe what this PR does and why -->
Implement GitHub Actions CD pipeline to automate deployment for the monorepo after code is merged into the target branches.

The deployment workflow should support both backend and frontend applications separately based on changed paths:
- backend/ → deploy NestJS + Prisma service
- frontend/ → deploy Next.js service

---

## Issue Link

<!-- Link to the issue -->
[[INFRA] Setup Github Actions CD pipeline](https://github.com/lyoven2004/todo-app/issues/69)

---

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Documentation update
- [ ] Test update
- [ ] Build / CI update
- [x] Chore / Maintenance
